### PR TITLE
prudebug: Add BBAI support 

### DIFF
--- a/pru/prudebug/README.md
+++ b/pru/prudebug/README.md
@@ -62,6 +62,7 @@ arm-none-linux-gnueabi-gcc).  The binary is called prudebug.
 
 USAGE
 ---------------------------------------------------------------------
+```
 Usage: prudebug [-a pruss-address] [-u] [-m] [-p processor]
     -a - pruss-address is the memory address of the PRU in ARM memory space
     -u - force the use of UIO to map PRU memory space
@@ -70,6 +71,9 @@ Usage: prudebug [-a pruss-address] [-u] [-m] [-p processor]
     -p - select processor to use (sets the PRU memory locations)
         AM1707 - AM1707
         AM335X - AM335x
+        AM57X1 - AM57x1
+        AM57X2 - AM57x2
+```
 
 Generally the -a option should not be used.  If it is used, then prudebug will use the -a address for the PRU base with
 the selected processor as the various PRU subsystem offsets.  -u and -m control the way the PRU base address is mapped for

--- a/pru/prudebug/prudbg.c
+++ b/pru/prudebug/prudbg.c
@@ -103,6 +103,44 @@ struct pdb_tag {
 			}
 		}
 	},
+	{
+		.processor              = "AM57x1",
+		.short_name     = "AM57X1",
+		.pruss_address  = 0x4b200000,
+		.pruss_len              = 0x80000,
+		.num_of_pruss   = 2,
+		.offsets        = {
+			{
+				.pruss_inst     = 0x34000,
+				.pruss_data     = 0x00000,
+				.pruss_ctrl     = 0x22000
+			},
+			{
+				.pruss_inst     = 0x38000,
+				.pruss_data     = 0x02000,
+				.pruss_ctrl     = 0x24000
+			}
+		}
+	},
+	{
+		.processor              = "AM57x2",
+		.short_name     = "AM57X2",
+		.pruss_address  = 0x4b280000,
+		.pruss_len              = 0x80000,
+		.num_of_pruss   = 2,
+		.offsets        = {
+			{
+				.pruss_inst     = 0x34000,
+				.pruss_data     = 0x00000,
+				.pruss_ctrl     = 0x22000
+			},
+			{
+				.pruss_inst     = 0x38000,
+				.pruss_data     = 0x02000,
+				.pruss_ctrl     = 0x24000
+			}
+		}
+	},
 	{	// end marker
 		.processor	= "NONE",
 		.short_name	= "NONE",

--- a/pru/prudebug/prudbg.h
+++ b/pru/prudebug/prudbg.h
@@ -10,14 +10,15 @@
 #define PRUDBG_H
 
 // default processor to use if none is specified on the command line when prudebug is started
-#define DEFAULT_PROCESSOR_INDEX	AM335x
+#define DEFAULT_PROCESSOR_INDEX	AM57x1
 
 // list of processors to use in the define above (DEFAULT_PROCESSOR_INDEX)
 // value for define must match the array index in the processor structure
 // in the prudbg.c file.
 #define AM1707			0
 #define AM335x			1
-
+#define AM57x1			2
+#define AM57x2			3
 
 // general settings
 #define MAX_CMD_LEN		25


### PR DESCRIPTION
- Add feature as requested in issue https://github.com/MarkAYoder/BeagleBoard-exercises/issues/6

- Details on how I tested this code can be found on this blog: https://dhruvag2000.github.io/Blog-GSoC21/prudebug.html
  - This has been built and tested on **BeagleBone AI** running  `Linux beaglebone 4.19.94-ti-xenomai-r64 #1buster SMP PREEMPT Sat May 22 01:02:28 UTC 2021 armv7l GNU/Linux`
  - It also contains recording of the terminal session where I show:
  - Building the asm blink LED program.
  - loading the `.out` file onto PRU1 core1.
  - using prudebug to actually step through each instruction live on the BBAI.

**Files modified:**

- modified:   prudbg.c
Added the base addresses for PRU ICSS 1 and 2 by the names AM57x1 and 2

- modified:   prudbg.h
Changed the default from AM335x to AM57x1

- renamed:    README -> README.md
Also specify BBAI PRU options in the USAGE section